### PR TITLE
Development

### DIFF
--- a/Examples/5_Monolayer.md
+++ b/Examples/5_Monolayer.md
@@ -36,6 +36,7 @@ mono2 = q2d.create_perovskite(
 
 ### When you add spacers and penetration
 - Provide `spacer="CCCC[NH3+]"` (SMILES) or a list; external L1 A-sites become Ap-sites and get populated by spacers.
+- `spacer=None` (default): No Ap-sites are created. External L1 A-sites remain as regular A-sites and get populated with A-ions (not left as holes).
 - `penetration` is a float or list (fractions of `BX_dist`) cycling over external A/Ap sites; positive moves out, negative moves in.
 
 ### Practical tips

--- a/q2D_Materials/builders/__init__.py
+++ b/q2D_Materials/builders/__init__.py
@@ -6,7 +6,7 @@ populated structure matrices and eventually ASE Atoms objects.
 """
 
 from .q_builder import QBuilderOutput, calculate_lattice_vectors, build_structure_matrix
-from .population import (
+from .populate import (
     normalize_a_site, assign_ions_to_sites, populate_structure, attach_spacers
 )
 

--- a/q2D_Materials/builders/glazer_tilting.py
+++ b/q2D_Materials/builders/glazer_tilting.py
@@ -73,17 +73,20 @@ def _deduplicate_positions_pbc(
     return [u.tolist() for u in unique]
 
 
-def _kvecs_from_pattern(angles: List[float], tilt_pattern: List[str]) -> List[np.ndarray]:
-    """Build k-vectors (phase) per Glazer sign."""
+def _kvecs_from_pattern(
+    angles: List[float], tilt_pattern: List[str]
+) -> Tuple[List[np.ndarray], List[float]]:
+    """Build k-vectors (phase) per Glazer sign, returning adjusted angles."""
     if len(angles) != 3 or len(tilt_pattern) != 3:
         raise ValueError("angles and tilt_pattern must have length 3")
+    angles_adj = list(angles)
     kvecs = []
     for i, pat in enumerate(tilt_pattern):
-        ang = angles[i]
+        ang = angles_adj[i]
         if ang == 0.0 and pat != "0":
             pat = "0"
         if pat == "0" and ang != 0.0:
-            angles[i] = 0.0
+            angles_adj[i] = 0.0
         if pat == "0":
             kvecs.append(np.array([0, 0, 0], dtype=int))
         elif pat == "+":
@@ -94,7 +97,7 @@ def _kvecs_from_pattern(angles: List[float], tilt_pattern: List[str]) -> List[np
             kvecs.append(np.array([1, 1, 1], dtype=int))
         else:
             raise ValueError("tilt_pattern entries must be '+', '-', or '0'")
-    return kvecs
+    return kvecs, angles_adj
 
 
 def _adjust_network_connectivity(
@@ -187,7 +190,7 @@ def apply_glazer_tilt(
     lv = np.asarray(lattice_vectors, dtype=float)
     nx, ny, nz = supercell
     cell_len = lv * np.asarray(supercell, dtype=float)
-    kvecs = _kvecs_from_pattern(angles, tilt_pattern)
+    kvecs, angles_eff = _kvecs_from_pattern(angles, tilt_pattern)
 
     # Build cell index -> B positions for nearest-center lookup
     b_cells: Dict[Tuple[int, int, int], List[np.ndarray]] = {}
@@ -217,10 +220,10 @@ def apply_glazer_tilt(
         shift = np.array([ix, iy, iz], dtype=int)
         rot_total = np.eye(3)
         for ax, axis_name in enumerate(["x", "y", "z"]):
-            if angles[ax] == 0.0:
+            if angles_eff[ax] == 0.0:
                 continue
             phase = (-1) ** int(np.dot(shift, kvecs[ax]))
-            ang_signed = angles[ax] * phase
+            ang_signed = angles_eff[ax] * phase
             rot_total = _rotation_matrix(axis_name, ang_signed) @ rot_total
 
         rel = xvec - b_center

--- a/q2D_Materials/builders/populate.py
+++ b/q2D_Materials/builders/populate.py
@@ -165,19 +165,27 @@ def assign_ions_to_sites(
                 assignments.append(('A', ion, pos))
 
     # Assign Ap-site positions (optional spacers)
+    # "HOLE" string in Ap_ions list or as single value creates holes (skip assignment for that position)
     if Ap_ions is not None and len(Ap_positions) > 0:
         if isinstance(Ap_ions, list):
             for i, pos in enumerate(Ap_positions):
                 ion = Ap_ions[i % len(Ap_ions)]
+                if isinstance(ion, str) and ion.upper() == "HOLE":
+                    continue  # Skip this position - creates a hole
                 if isinstance(ion, Atoms):
                     ion = ion.copy()
                 assignments.append(('Ap', ion, pos))
         else:
-            for pos in Ap_positions:
-                ion = Ap_ions
-                if isinstance(ion, Atoms):
-                    ion = ion.copy()
-                assignments.append(('Ap', ion, pos))
+            # Single spacer value - check if it's "HOLE"
+            if isinstance(Ap_ions, str) and Ap_ions.upper() == "HOLE":
+                # Skip all positions - creates holes everywhere
+                pass
+            else:
+                for pos in Ap_positions:
+                    ion = Ap_ions
+                    if isinstance(ion, Atoms):
+                        ion = ion.copy()
+                    assignments.append(('Ap', ion, pos))
     
     # Assign B-site positions
     if len(B_positions) > 0:

--- a/q2D_Materials/builders/q_builder.py
+++ b/q2D_Materials/builders/q_builder.py
@@ -1,7 +1,7 @@
 """
 Lightweight container and helpers for structure matrices.
 
-QBuilderOutput mirrors the minimal fields consumed by population.populate_structure.
+QBuilderOutput mirrors the minimal fields consumed by populate.populate_structure.
 """
 
 from dataclasses import dataclass

--- a/q2D_Materials/core/creator.py
+++ b/q2D_Materials/core/creator.py
@@ -1,4 +1,8 @@
-from ..pipeline import create_bulk_perovskite, create_monolayer_perovskite, auto_calculate_BX_distance
+from ..pipeline import (
+    create_bulk_perovskite,
+    create_monolayer_perovskite,
+    auto_calculate_BX_distance,
+)
 from .structure import q2DStructure
 import numpy as np
 from math import gcd

--- a/q2D_Materials/pipeline/__init__.py
+++ b/q2D_Materials/pipeline/__init__.py
@@ -9,8 +9,16 @@ from .perovskite import (
     create_perovskite,
     create_bulk_perovskite,
     create_monolayer_perovskite,
+)
+from .common import (
     auto_calculate_BX_distance,
-    get_template
+    resolve_BX_distance,
+    normalize_spacer,
+    build_cell_positions,
+    apply_glazer_tilting,
+    populate_positions,
+    default_layer_sequence,
+    get_template,
 )
 
 __all__ = [
@@ -18,6 +26,12 @@ __all__ = [
     'create_bulk_perovskite',
     'create_monolayer_perovskite',
     'auto_calculate_BX_distance',
+    'resolve_BX_distance',
+    'normalize_spacer',
+    'build_cell_positions',
+    'apply_glazer_tilting',
+    'populate_positions',
+    'default_layer_sequence',
     'get_template',
 ]
 

--- a/q2D_Materials/pipeline/common.py
+++ b/q2D_Materials/pipeline/common.py
@@ -1,0 +1,193 @@
+"""
+Shared helpers for perovskite pipeline entry points.
+
+This module centralizes reusable steps such as template selection,
+Glazer tilting, BX distance resolution, spacer normalization, and population.
+"""
+
+from typing import List, Tuple, Optional, Dict
+
+import numpy as np
+from ase import Atoms
+
+from q2D_Materials.builders.templates import (
+    load_template,
+    available_templates,
+    build_bulk_cell,
+    build_structure_matrix,
+)
+from q2D_Materials.builders.glazer_tilting import apply_glazer_tilt
+from q2D_Materials.builders.populate import populate_structure
+from q2D_Materials.utils.A_sites import (
+    calculate_BX_distance,
+    get_a_site_object,
+)
+from q2D_Materials.utils.molecule_builder import smiles_to_ase_atoms
+
+
+def get_template(template_name: str) -> str:
+    """Return a template name, validating it exists (based on available JSONs)."""
+    name = template_name.lower()
+    valid = available_templates()
+    if name not in valid:
+        raise ValueError(f"template must be one of {valid}")
+    return name
+
+
+def auto_calculate_BX_distance(B: str, X: str) -> float:
+    """Calculate BX distance from ionic radii data with a small fallback."""
+    try:
+        return calculate_BX_distance(B, X)
+    except ValueError:
+        return 2.0
+
+
+def resolve_BX_distance(B, X, BX_dist: float | None) -> float:
+    """
+    Return the BX distance, computing it when not provided.
+    Accepts either single species or lists/tuples.
+    """
+    if BX_dist is not None:
+        return BX_dist
+    B_first = B[0] if isinstance(B, (list, tuple)) else B
+    X_first = X[0] if isinstance(X, (list, tuple)) else X
+    return auto_calculate_BX_distance(B_first, X_first)
+
+
+def normalize_spacer(spacer):
+    """
+    Normalize spacer input to handle strings (SMILES or abbreviations) and Atoms objects.
+    
+    Supports both atomic spacers (e.g., "Cs", "Rb", "K") and molecular spacers (SMILES strings).
+
+    Parameters
+    ----------
+    spacer : str or Atoms
+        Spacer molecule as SMILES string, abbreviation, or Atoms object
+
+    Returns
+    -------
+    Atoms
+        ASE Atoms object of the spacer molecule or atom
+    """
+    if isinstance(spacer, Atoms):
+        return spacer.copy()
+
+    if isinstance(spacer, str):
+        try:
+            normalized = get_a_site_object(spacer)
+            if isinstance(normalized, Atoms):
+                return normalized
+            if isinstance(normalized, str):
+                try:
+                    from pymatgen.core.periodic_table import Element
+
+                    try:
+                        Element(normalized)
+                        return Atoms(normalized, positions=[[0, 0, 0]])
+                    except (ValueError, KeyError):
+                        pass
+                except ImportError:
+                    atomic_spacers = ['Cs', 'K', 'Rb', 'Na', 'Li', 'Ca', 'Sr', 'Ba', 'Mg']
+                    if normalized in atomic_spacers:
+                        return Atoms(normalized, positions=[[0, 0, 0]])
+                    if len(normalized) <= 2 and normalized[0].isupper():
+                        return Atoms(normalized, positions=[[0, 0, 0]])
+        except (ValueError, ImportError):
+            pass
+
+        try:
+            if smiles_to_ase_atoms is not None:
+                return smiles_to_ase_atoms(spacer)
+            else:
+                raise ValueError("RDKit not available for SMILES processing")
+        except Exception as e:
+            raise ValueError(f"Failed to parse spacer '{spacer}' as SMILES or abbreviation: {e}")
+
+    raise ValueError(f"Spacer must be a string (SMILES or abbreviation) or Atoms object, got {type(spacer)}")
+
+
+def build_cell_positions(
+    template_name: str,
+    BX_dist: float,
+    jahn_teller_dist: float,
+    layer_sequence: Optional[List[str] | str] = None,
+    xy_expansion: Tuple[int, int] = (1, 1),
+    penetration: float = 0.0,
+    spacer_provided: bool = False,
+) -> Dict[str, object]:
+    """Select the correct builder for a template and return positions/lattice/cell for unit cell."""
+    tpl_data = load_template(
+        template_name,
+        BX_dist=BX_dist,
+        jahn_teller_dist=jahn_teller_dist,
+        layer_sequence=layer_sequence,
+        penetration=penetration,
+        spacer_provided=spacer_provided,
+    )
+
+    return build_bulk_cell(
+        tpl_data,
+        xy_expansion=xy_expansion,
+    )
+
+
+def apply_glazer_tilting(
+    positions: Dict[str, List[List[float]]],
+    cell_matrix: np.ndarray,
+    glazer_angles: Optional[List[float]],
+    glazer_pattern: Optional[List[str]],
+) -> Tuple[Dict[str, List[List[float]]], np.ndarray, np.ndarray]:
+    """
+    Apply Glazer tilt if requested, otherwise return inputs unchanged.
+
+    Glazer tilting applies octahedral rotations to X-sites about their nearest B-site centers,
+    following the specified angle and pattern parameters.
+    """
+    lattice_vec_sizes = np.linalg.norm(cell_matrix, axis=1)
+
+    if glazer_angles is not None and glazer_pattern is not None:
+        if len(glazer_angles) == 3 and len(glazer_pattern) == 3:
+            supercell_size = (1, 1, 1)
+
+            tilted_positions, _, _ = apply_glazer_tilt(
+                position_matrix=positions,
+                lattice_vectors=tuple(lattice_vec_sizes),
+                supercell=supercell_size,
+                angles=glazer_angles,
+                tilt_pattern=glazer_pattern,
+                adjust_cell=True
+            )
+            return tilted_positions, lattice_vec_sizes, cell_matrix
+
+    return positions, lattice_vec_sizes, cell_matrix
+
+
+def populate_positions(
+    positions: Dict[str, List[List[float]]],
+    lattice_vec_sizes: np.ndarray,
+    cell_matrix: np.ndarray,
+    A,
+    B,
+    X,
+    Ap_ions=None,
+) -> Atoms:
+    """Populate ions using the population toolchain."""
+    positions_np = {site: np.asarray(coords, dtype=float) for site, coords in positions.items()}
+    matrix = build_structure_matrix(positions_np, lattice_vec_sizes, cell_vectors=cell_matrix)
+    return populate_structure(
+        matrix=matrix,
+        A_ions=A,
+        B_ions=B,
+        X_ions=X,
+        Ap_ions=Ap_ions,
+    )
+
+
+def default_layer_sequence(layer_sequence: Optional[str], thickness: int) -> str:
+    """Return the default layer sequence for a given monolayer thickness if not provided."""
+    if layer_sequence is None:
+        return "-".join(["L1-L2"] * thickness) + "-L1"
+    else:
+        return layer_sequence
+

--- a/q2D_Materials/pipeline/perovskite.py
+++ b/q2D_Materials/pipeline/perovskite.py
@@ -5,185 +5,20 @@ This module wires templates -> base cell builder -> population to produce
 ASE Atoms objects. Currently only bulk is implemented here.
 """
 
-from typing import List, Tuple, Optional, Dict
+from typing import List, Tuple, Optional
 
-import numpy as np
 from ase import Atoms
 from ase.build import add_vacuum
 
-from q2D_Materials.builders.templates import (
-    load_template,
-    available_templates,
-    build_bulk_cell,
-    build_structure_matrix,
+from q2D_Materials.pipeline.common import (
+    apply_glazer_tilting,
+    build_cell_positions,
+    default_layer_sequence,
+    get_template,
+    normalize_spacer,
+    populate_positions,
+    resolve_BX_distance,
 )
-from q2D_Materials.builders.glazer_tilting import apply_glazer_tilt
-from q2D_Materials.builders.population import populate_structure
-from q2D_Materials.builders.molecule_builder import com_to_origin
-# Glazer tilting functionality removed for minimal implementation
-from q2D_Materials.utils.A_sites import calculate_BX_distance
-from q2D_Materials.builders.population import normalize_a_site
-from q2D_Materials.utils.molecule_builder import smiles_to_ase_atoms
-from q2D_Materials.utils.A_sites import get_a_site_object, is_molecular_a_cation
-
-
-def get_template(template_name: str) -> str:
-    """Return a template name, validating it exists (based on available JSONs)."""
-    name = template_name.lower()
-    valid = available_templates()
-    if name not in valid:
-        raise ValueError(f"template must be one of {valid}")
-    return name
-
-
-def auto_calculate_BX_distance(B: str, X: str) -> float:
-    """Calculate BX distance from ionic radii data with a small fallback."""
-    try:
-        return calculate_BX_distance(B, X)
-    except ValueError:
-        return 2.0
-
-
-def normalize_spacer(spacer):
-    """
-    Normalize spacer input to handle strings (SMILES or abbreviations) and Atoms objects.
-    
-    Supports both atomic spacers (e.g., "Cs", "Rb", "K") and molecular spacers (SMILES strings).
-
-    Parameters
-    ----------
-    spacer : str or Atoms
-        Spacer molecule as SMILES string, abbreviation, or Atoms object
-
-    Returns
-    -------
-    Atoms
-        ASE Atoms object of the spacer molecule or atom
-    """
-    if isinstance(spacer, Atoms):
-        return spacer.copy()
-
-    if isinstance(spacer, str):
-        # First try to treat as an A-site cation abbreviation
-        try:
-            normalized = get_a_site_object(spacer)
-            if isinstance(normalized, Atoms):
-                return normalized
-            # If it's a string (atomic cation), convert to Atoms object
-            if isinstance(normalized, str):
-                # Check if it's a valid atomic element symbol
-                # Use pymatgen if available for robust validation
-                try:
-                    from pymatgen.core.periodic_table import Element
-                    try:
-                        Element(normalized)
-                        # Valid element symbol - create Atoms object
-                        return Atoms(normalized, positions=[[0, 0, 0]])
-                    except (ValueError, KeyError):
-                        # Not a valid element symbol, continue to SMILES parsing
-                        pass
-                except ImportError:
-                    # Fallback: check common atomic A-site cations
-                    atomic_spacers = ['Cs', 'K', 'Rb', 'Na', 'Li', 'Ca', 'Sr', 'Ba', 'Mg']
-                    if normalized in atomic_spacers:
-                        return Atoms(normalized, positions=[[0, 0, 0]])
-                    # Also check simple pattern: 1-2 chars, first uppercase
-                    if len(normalized) <= 2 and normalized[0].isupper():
-                        return Atoms(normalized, positions=[[0, 0, 0]])
-        except (ValueError, ImportError):
-            pass
-
-        # Try to treat as raw SMILES string
-        try:
-            if smiles_to_ase_atoms is not None:
-                return smiles_to_ase_atoms(spacer)
-            else:
-                raise ValueError("RDKit not available for SMILES processing")
-        except Exception as e:
-            raise ValueError(f"Failed to parse spacer '{spacer}' as SMILES or abbreviation: {e}")
-
-    raise ValueError(f"Spacer must be a string (SMILES or abbreviation) or Atoms object, got {type(spacer)}")
-
-
-def _build_positions(
-    template_name: str,
-    BX_dist: float,
-    jahn_teller_dist: float,
-    layer_sequence: Optional[List[str] | str] = None,
-    xy_expansion: Tuple[int, int] = (1, 1),
-    penetration: float = 0.0,
-    spacer_provided: bool = False,
-) -> Dict[str, object]:
-    """Select the correct builder for a template and return positions/lattice/cell for unit cell."""
-    tpl_data = load_template(
-        template_name,
-        BX_dist=BX_dist,
-        jahn_teller_dist=jahn_teller_dist,
-        layer_sequence=layer_sequence,
-        penetration=penetration,
-        spacer_provided=spacer_provided,
-    )
-
-    return build_bulk_cell(
-        tpl_data,
-        xy_expansion=xy_expansion,
-    )
-
-
-def _apply_glazer_if_any(
-    positions: Dict[str, List[List[float]]],
-    cell_matrix: np.ndarray,
-    glazer_angles: Optional[List[float]],
-    glazer_pattern: Optional[List[str]],
-) -> Tuple[Dict[str, List[List[float]]], np.ndarray, np.ndarray]:
-    """
-    Apply Glazer tilt if requested, otherwise return inputs unchanged.
-
-    Glazer tilting applies octahedral rotations to X-sites about their nearest B-site centers,
-    following the specified angle and pattern parameters.
-    """
-    lattice_vec_sizes = np.linalg.norm(cell_matrix, axis=1)
-
-    # Apply Glazer tilting if angles and pattern are provided
-    if glazer_angles is not None and glazer_pattern is not None:
-        if len(glazer_angles) == 3 and len(glazer_pattern) == 3:
-            # Determine supercell size from cell_matrix dimensions
-            # The cell_matrix represents the supercell vectors
-            supercell_size = (1, 1, 1)  # Default for monolayers
-
-            # Apply Glazer tilting
-            tilted_positions, _, _ = apply_glazer_tilt(
-                position_matrix=positions,
-                lattice_vectors=tuple(lattice_vec_sizes),
-                supercell=supercell_size,
-                angles=glazer_angles,
-                tilt_pattern=glazer_pattern,
-                adjust_cell=True
-            )
-            return tilted_positions, lattice_vec_sizes, cell_matrix
-
-    return positions, lattice_vec_sizes, cell_matrix
-
-
-def _populate(
-    positions: Dict[str, List[List[float]]],
-    lattice_vec_sizes: np.ndarray,
-    cell_matrix: np.ndarray,
-    A,
-    B,
-    X,
-    Ap_ions=None,
-) -> Atoms:
-    """Populate ions using the population toolchain."""
-    positions_np = {site: np.asarray(coords, dtype=float) for site, coords in positions.items()}
-    matrix = build_structure_matrix(positions_np, lattice_vec_sizes, cell_vectors=cell_matrix)
-    return populate_structure(
-        matrix=matrix,
-        A_ions=A,
-        B_ions=B,
-        X_ions=X, # This must be expanded before being passed to the population toolchain in fact all of them is a good idea A, B, X, Ap must be expanded before being passed to the population toolchain
-        Ap_ions=Ap_ions,
-    )
 
 
 def create_bulk_perovskite(
@@ -203,13 +38,9 @@ def create_bulk_perovskite(
     Build a bulk perovskite using a chosen geometry template and populate it.
     Applies XY expansion within the layer plane.
     """
-    if BX_dist is None:
-        B_first = B[0] if isinstance(B, (list, tuple)) else B
-        X_first = X[0] if isinstance(X, (list, tuple)) else X
-        BX_dist = auto_calculate_BX_distance(B_first, X_first)
-
+    BX_dist = resolve_BX_distance(B, X, BX_dist)
     tpl = get_template(template)
-    cell_data = _build_positions(
+    cell_data = build_cell_positions(
         tpl,
         BX_dist=BX_dist,
         jahn_teller_dist=jahn_teller_dist,
@@ -219,14 +50,14 @@ def create_bulk_perovskite(
     positions = cell_data["positions"]
     unit_cell_matrix = cell_data["unit_cell_matrix"]
 
-    positions, lattice_vec_sizes, cell_matrix = _apply_glazer_if_any(
+    positions, lattice_vec_sizes, cell_matrix = apply_glazer_tilting(
         positions,
         unit_cell_matrix,
         glazer_angles,
         glazer_pattern,
     )
 
-    atoms = _populate(positions, lattice_vec_sizes, cell_matrix, A, B, X)
+    atoms = populate_positions(positions, lattice_vec_sizes, cell_matrix, A, B, X)
     
     return atoms
 
@@ -245,24 +76,18 @@ def create_monolayer_perovskite(
     layer_sequence: Optional[List[str] | str] = None,
     spacer: str | List[str] | Atoms = None,
     penetration: float = 0.0,
+    attachment_end: Optional[str] = None,
 ) -> Atoms:
     """
     Build a monolayer perovskite using a chosen geometry template and populate it.
     Replace the X of terminal positions with the X of the spacer.
     Applies XY expansion within the layer plane.
     """
-    if BX_dist is None:
-        B_first = B[0] if isinstance(B, (list, tuple)) else B
-        X_first = X[0] if isinstance(X, (list, tuple)) else X
-        BX_dist = auto_calculate_BX_distance(B_first, X_first)
-    
-    if layer_sequence is None:
-        layer_sequence = "-".join(["L1-L2"] * thickness) + "-L1"
-
-
+    BX_dist = resolve_BX_distance(B, X, BX_dist)
+    layer_sequence = default_layer_sequence(layer_sequence, thickness)
 
     tpl = get_template(template)
-    cell_data = _build_positions(
+    cell_data = build_cell_positions(
         tpl,
         BX_dist=BX_dist,
         jahn_teller_dist=jahn_teller_dist,
@@ -274,7 +99,7 @@ def create_monolayer_perovskite(
     positions = cell_data["positions"]
     unit_cell_matrix = cell_data["unit_cell_matrix"]
 
-    positions, lattice_vec_sizes, cell_matrix = _apply_glazer_if_any(
+    positions, lattice_vec_sizes, cell_matrix = apply_glazer_tilting(
         positions,
         unit_cell_matrix,
         glazer_angles,
@@ -282,14 +107,24 @@ def create_monolayer_perovskite(
     )
 
     # Normalize spacer (Ap_ions) - spacers can be SMILES strings or abbreviations
+    # "HOLE" string in lists or as single value creates holes (unpopulated Ap positions)
     Ap_ions = None
     if spacer is not None:
         if isinstance(spacer, list):
-            Ap_ions = [normalize_spacer(s) for s in spacer]
+            Ap_ions = []
+            for s in spacer:
+                if isinstance(s, str) and s.upper() == "HOLE":
+                    Ap_ions.append("HOLE")  # Keep "HOLE" to create unpopulated positions
+                else:
+                    Ap_ions.append(normalize_spacer(s))
         else:
-            Ap_ions = normalize_spacer(spacer)
+            # Check if single spacer value is "HOLE"
+            if isinstance(spacer, str) and spacer.upper() == "HOLE":
+                Ap_ions = "HOLE"
+            else:
+                Ap_ions = normalize_spacer(spacer)
 
-    atoms = _populate(positions, lattice_vec_sizes, cell_matrix, A, B, X, Ap_ions)
+    atoms = populate_positions(positions, lattice_vec_sizes, cell_matrix, A, B, X, Ap_ions)
 
     # Add vacuum then center the slab symmetrically around mid-cell in Z
     add_vacuum(atoms, vacuum=vacuum)
@@ -311,4 +146,6 @@ def create_perovskite(structure_type="bulk", **kwargs):
         return create_bulk_perovskite(**kwargs)
     if stype == "monolayer":
         return create_monolayer_perovskite(**kwargs)
+    if stype == "bilayer":
+        return create_bilayer_perovskite(**kwargs)
     raise NotImplementedError(f"{structure_type} creation is not implemented yet.")

--- a/tests/test_creator_dj.py
+++ b/tests/test_creator_dj.py
@@ -1,0 +1,22 @@
+from q2D_Materials.core.creator import q2D_creator
+from q2D_Materials.core.structure import q2DStructure
+from ase.io import write
+
+def main():
+    q2d = q2D_creator()
+    atoms = q2d.create_perovskite(
+        A_ions="MA",
+        B_ions="Pb",
+        X_ions="I",
+        structure_type="bilayer",
+        thickness=2,
+        spacer="[NH3+]CCCC[NH3+]",
+        penetration=0.0,
+        glazer_angles=[0, 0, 3],
+        glazer_pattern=["0", "0", "+"],
+    )
+    write("DJ_perovskite.vasp", atoms, format="vasp", sort=True)
+    print("✓ Wrote DJ_perovskite.vasp")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors perovskite pipeline into shared helpers, enhances spacer/Ap handling (including "HOLE") and Glazer tilt angle-pattern logic, updates monolayer docs, and adds a bilayer test entry point.
> 
> - **Pipeline**:
>   - Extracts shared helpers into `pipeline/common.py` (`get_template`, `auto_calculate_BX_distance`, `resolve_BX_distance`, `normalize_spacer`, `build_cell_positions`, `apply_glazer_tilting`, `populate_positions`, `default_layer_sequence`).
>   - Refactors `perovskite.py` to use common helpers; simplifies bulk/monolayer creation and spacer handling; dispatcher recognizes `"bilayer"`.
>   - Updates `pipeline/__init__.py` to export new helpers.
> - **Builders**:
>   - Switch import to `builders/populate.py` in `builders/__init__.py`.
>   - `glazer_tilting._kvecs_from_pattern` now returns `(kvecs, angles_adj)`; `apply_glazer_tilt` uses adjusted angles.
>   - Minor doc fix in `q_builder.py` reference to `populate.populate_structure`.
> - **Population**:
>   - `assign_ions_to_sites` adds Ap-site hole support via `"HOLE"` sentinel (list or single) to skip spacer placement.
> - **Docs**:
>   - Monolayer guide clarifies `spacer=None` leaves external L1 A-sites as A (no Ap-sites created).
> - **Tests/Examples**:
>   - Adds `tests/test_creator_dj.py` bilayer creation script with spacer and Glazer tilt, writing `DJ_perovskite.vasp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8548965b51ac822734d66d1afd5d3fd91edbe92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->